### PR TITLE
Workflows: Add Godot Export

### DIFF
--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Export PCK file
         run: |
-          godot --verbose --headless --path=./game/project.godot --export-pack "Linux/X11" ${EXPORT_NAME}.pck
+          ./godot --verbose --headless --path=./game/project.godot --export-pack "Linux/X11" ${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -75,4 +75,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload '${{ github.ref_name }}' ${EXPORT_NAME}.pck --repo '${{ github.repository }}'
+          gh release upload '${{ github.ref_name }}' ${{ env.EXPORT_NAME }}.pck --repo '${{ github.repository }}'

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ./export/godot
-            ./export/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
+            export/godot
+            export/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
           key: godot-${{ env.GODOT_VERSION }}
 
       - name: Download Godot Engine from GitHub release
@@ -66,6 +66,11 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Download PCK file artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+
       - name: Upload PCK file to release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Export PCK file
         run: |
-          ./godot --verbose --headless --path=./game/project.godot --export-pack "Linux/X11" ${EXPORT_NAME}.pck
+          ./godot --verbose --headless --path=./game --export-pack "Linux/X11" ${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -1,0 +1,64 @@
+name: "Godot Export"
+on:
+  workflow_dispatch:
+  pull_request:
+  release:
+    types:
+      - released
+
+env:
+  GODOT_VERSION: 4.3
+  GODOT_SHA512: fd52bb4ba8acc30ca5accd1c566d470ad7282f891ccc0995dfafabcf92bcf76280ce182bf9d80ebd885f3ed2165d01e1fc3f2928436b15498dfbd98656c2a45a
+  TEMPLATES_SHA512: 476366caf0fd45a8f24136cf9cf1dc0bc2b96f7c82d53e5f82200b55aefd07b286d283fd6f1ce29e0de70648c5a51d3b12f96c6d4fafd4e8c4878ecda6406d6a
+  EXPORT_NAME: amaya
+
+jobs:
+  export:
+    name: Export
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Godot Engine
+        run: |
+          # Tell Godot Engine to be self-contained
+          touch ._sc_
+
+          # Download Godot Engine itself
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
+
+          # Download export templates
+          mkdir --verbose --parents ./editor_data/export_templates
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
+
+      - name: Export PCK file
+        run: |
+          godot --verbose --headless --path=./game/project.godot --export-pack "Linux/X11" ${EXPORT_NAME}.pck
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+          path: ${{ env.EXPORT_NAME }}.pck
+
+  release:
+    name: Release
+    needs: export
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.EXPORT_NAME }}
+
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload '${{ github.ref_name }}' ${EXPORT_NAME}.pck --repo '${{ github.repository }}'

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -61,6 +61,7 @@ jobs:
           path: export/${{ env.EXPORT_NAME }}.pck
 
   release:
+    permissions: write-all
     name: Release
     needs: export
     if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.EXPORT_NAME }}
-          path: ${{ env.EXPORT_NAME }}.pck
+          path: export/${{ env.EXPORT_NAME }}.pck
 
   release:
     name: Release

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Export PCK file
         run: |
           # NOTE: export filename is relative to the project path
-          ./export/godot --verbose --headless --path ../game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
+          ./export/godot --verbose --headless --path game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -8,8 +8,6 @@ on:
 
 env:
   GODOT_VERSION: 4.3
-  GODOT_SHA512: fd52bb4ba8acc30ca5accd1c566d470ad7282f891ccc0995dfafabcf92bcf76280ce182bf9d80ebd885f3ed2165d01e1fc3f2928436b15498dfbd98656c2a45a
-  TEMPLATES_SHA512: 476366caf0fd45a8f24136cf9cf1dc0bc2b96f7c82d53e5f82200b55aefd07b286d283fd6f1ce29e0de70648c5a51d3b12f96c6d4fafd4e8c4878ecda6406d6a
   EXPORT_NAME: amaya
 
 jobs:
@@ -20,13 +18,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Godot Engine
-        run: |
-          # Use export working directory
-          mkdir export && cd export
+      - name: Cache Godot Engine downloads
+        id: cache-downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./export/godot
+            ./export/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
+          key: ${{ env.GODOT_VERSION }}
 
-          # Tell Godot Engine to be self-contained
-          touch ._sc_
+      - name: Download Godot Engine from GitHub release
+        id: download
+        if: steps.cache-downloads.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p export && cd export
 
           # Download Godot Engine itself
           wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
@@ -34,15 +39,20 @@ jobs:
           mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
 
           # Download export templates
-          mkdir --verbose --parents ./editor_data/export_templates
+          mkdir -p editor_data/export_templates
           wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
           unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
           mv templates editor_data/export_templates/${GODOT_VERSION}.stable
 
       - name: Export PCK file
         run: |
+          cd export
+
+          # Tell Godot Engine to be self-contained
+          touch ._sc_
+
           # NOTE: export filename is relative to the project path
-          ./export/godot --verbose --headless --path game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
+          ./godot --verbose --headless --path ../game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -56,12 +66,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.EXPORT_NAME }}
-
-      - name: Upload to release
+      - name: Upload PCK file to release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Export PCK file
         run: |
           # NOTE: export filename is relative to the project path
-          ./godot --verbose --headless --path ../game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
+          ./export/godot --verbose --headless --path ../game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -19,17 +19,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache Godot Engine downloads
-        id: cache-downloads
+        id: cache-godot
         uses: actions/cache@v4
         with:
           path: |
             ./export/godot
             ./export/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
-          key: ${{ env.GODOT_VERSION }}
+          key: godot-${{ env.GODOT_VERSION }}
 
       - name: Download Godot Engine from GitHub release
         id: download
-        if: steps.cache-downloads.outputs.cache-hit != 'true'
+        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
           mkdir -p export && cd export
 
@@ -70,4 +70,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload '${{ github.ref_name }}' ${EXPORT_NAME}.pck --repo '${{ github.repository }}'
+          gh release upload '${{ github.ref_name }}' export/${EXPORT_NAME}.pck --repo '${{ github.repository }}'

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Set up Godot Engine
         run: |
+          # Use export working directory
+          mkdir export && cd export
+
           # Tell Godot Engine to be self-contained
           touch ._sc_
 
@@ -38,7 +41,8 @@ jobs:
 
       - name: Export PCK file
         run: |
-          ./godot --verbose --headless --path=./game --export-pack "Linux/X11" ${EXPORT_NAME}.pck
+          # NOTE: export filename is relative to the project path
+          ./godot --verbose --headless --path ../game --export-pack "Linux/X11" ../export/${EXPORT_NAME}.pck
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/godot-export.yml
+++ b/.github/workflows/godot-export.yml
@@ -75,4 +75,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release upload '${{ github.ref_name }}' export/${EXPORT_NAME}.pck --repo '${{ github.repository }}'
+          gh release upload '${{ github.ref_name }}' ${EXPORT_NAME}.pck --repo '${{ github.repository }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Godot 4+ specific ignores
 game/.godot/
 dist/
+
+# CI ignores
+export/


### PR DESCRIPTION
Downloads Godot Engine and the export templates, then uses them to export a PCK file. Uploads the resulting PCK file to the job, and, if triggered by a release, attaches it to the release.